### PR TITLE
Export `rand` correctly to `ark_std::rand`

### DIFF
--- a/std/src/lib.rs
+++ b/std/src/lib.rs
@@ -45,8 +45,8 @@ pub mod error;
 pub use std::*;
 
 pub use rand;
-mod rand;
-pub use self::rand::*;
+mod rand_helper;
+pub use rand_helper::*;
 
 /// Returns the base-2 logarithm of `x`.
 ///

--- a/std/src/lib.rs
+++ b/std/src/lib.rs
@@ -44,7 +44,6 @@ pub mod error;
 #[doc(hidden)]
 pub use std::*;
 
-pub use rand;
 mod rand_helper;
 pub use rand_helper::*;
 

--- a/std/src/lib.rs
+++ b/std/src/lib.rs
@@ -44,6 +44,7 @@ pub mod error;
 #[doc(hidden)]
 pub use std::*;
 
+pub use rand;
 mod rand;
 pub use self::rand::*;
 

--- a/std/src/rand_helper.rs
+++ b/std/src/rand_helper.rs
@@ -4,7 +4,6 @@ use rand::{
     Rng,
 };
 
-pub use rand;
 pub use rand_xorshift::XorShiftRng;
 
 pub trait UniformRand: Sized {

--- a/std/src/rand_helper.rs
+++ b/std/src/rand_helper.rs
@@ -4,6 +4,7 @@ use rand::{
     Rng,
 };
 
+pub use rand;
 pub use rand_xorshift::XorShiftRng;
 
 pub trait UniformRand: Sized {


### PR DESCRIPTION
The prior PR #21 has a small issue: 

1. `ark_std::rand` is private.
2. `ark_std::rand::rand` (since ark_std::rand do `pub use rand`) is not being exported by `pub use self::rand::*` since `ark_std::rand` already exists.

This PR renames `mod rand` into `mod rand_helper`. Note that this is not a breaking change since `mod rand` is private and cannot be accessed from the outside.