### PR TITLE
Bump `rand` to 0.8 and remove `rand_xorshift`

### DIFF
--- a/std/Cargo.toml
+++ b/std/Cargo.toml
@@ -13,10 +13,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-rand = { version = "0.7", default-features = false }
-# rand = { version = "0.8", default-features = false, features = ["std_rng"] }
-rand_xorshift = "0.2"
-# rand_xorshift = "0.3"
+rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 rayon = { version = "1", optional = true }
 
 [features]

--- a/std/src/rand_helper.rs
+++ b/std/src/rand_helper.rs
@@ -5,7 +5,6 @@ use rand::{
 };
 
 pub use rand;
-pub use rand_xorshift::XorShiftRng;
 
 pub trait UniformRand: Sized {
     fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self;


### PR DESCRIPTION
This is currently a draft PR, since there are still a number of libraries in `arkworks-rs` that needs to be adjusted to `ark_std::rand`, including the public repos `crypto-primitives`, `curves`, `pcd` and some private repos.

Since we have `test_rng`, it is planned to retire `rand_xorshift`.