### PR TITLE
Bump `rand` to 0.8 and remove `rand_xorshift`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,8 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-rand = { version = "0.7", default-features = false }
-# rand = { version = "0.8", default-features = false, features = ["std_rng"] }
-rand_xorshift = "0.2"
-# rand_xorshift = "0.3"
+rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 rayon = { version = "1", optional = true }
-
 colored = { version = "2", optional = true }
 
 

--- a/src/rand_helper.rs
+++ b/src/rand_helper.rs
@@ -5,7 +5,6 @@ use rand::{
 };
 
 pub use rand;
-pub use rand_xorshift::XorShiftRng;
 
 pub trait UniformRand: Sized {
     fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self;


### PR DESCRIPTION
## Description

As all the upstream repos have been modified to use `ark_std::rand`, this PR is ready.

This is related to #24.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code