### PR TITLE
Add necessary zero to duration decimals

### DIFF
--- a/src/perf_trace.rs
+++ b/src/perf_trace.rs
@@ -97,11 +97,11 @@ pub mod inner {
                 let micros = final_time.subsec_micros() % 1000;
                 let nanos = final_time.subsec_nanos() % 1000;
                 if secs != 0 {
-                    format!("{}.{}s", secs, millis).bold()
+                    format!("{}.{:03}s", secs, millis).bold()
                 } else if millis > 0 {
-                    format!("{}.{}ms", millis, micros).bold()
+                    format!("{}.{:03}ms", millis, micros).bold()
                 } else if micros > 0 {
-                    format!("{}.{}µs", micros, nanos).bold()
+                    format!("{}.{:03}µs", micros, nanos).bold()
                 } else {
                     format!("{}ns", final_time.subsec_nanos()).bold()
                 }


### PR DESCRIPTION
Right now we print "1.003ms" as "1.3ms" in the performance trace information, which is unfortunate.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
