### PR TITLE
Release v0.3.0 / Re-export `num_traits::{One, Zero}` from `ark-std`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,21 @@
 
 ### Breaking changes
 
+### Features
+
+### Improvements
+
+### Bug fixes
+
+## v0.3.0
+
+### Breaking changes
+
 - [\#32](https://github.com/arkworks-rs/utils/pull/32) Bump `rand` to 0.8 and remove the use of `rand_xorshift`.
 
 ### Features
+
+- []() Re-export `num_traits::{One, Zero}` from `ark-std`.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Features
 
-- []() Re-export `num_traits::{One, Zero}` from `ark-std`.
+- [\#34](https://github.com/arkworks-rs/utils/pull/34) Re-export `num_traits::{One, Zero}` from `ark-std`.
 
 ### Improvements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-std"
-version = "0.2.1-alpha.0"
+version = "0.3.0"
 authors = [ "arkworks contributors" ]
 description = "A library for no_std compatibility"
 homepage = "https://arkworks.rs"
@@ -16,7 +16,7 @@ edition = "2018"
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 rayon = { version = "1", optional = true }
 colored = { version = "2", optional = true }
-
+num-traits = { version = "0.2", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub use rand_helper::*;
 
 pub mod perf_trace;
 
+pub use num_traits::{One, Zero};
+
 /// Returns the ceiling of the base-2 logarithm of `x`.
 ///
 /// ```


### PR DESCRIPTION
## Description

This PR re-exports `num_traits::{One, Zero}` from `ark-std` as well as prepares this repo for a release to `crates.io`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code